### PR TITLE
ASP.NET Core RC2 to 1.0

### DIFF
--- a/src/Enact.Api/Config/DependencyInjection.cs
+++ b/src/Enact.Api/Config/DependencyInjection.cs
@@ -21,7 +21,7 @@ namespace Enact.Api.Config
             services.AddDependencyScanning().ScanAllAssemblies();
 
             //manual DI configuration goes here
-
+            services.AddSingleton(_ => config);
             services.AddSingleton(_ => new ElasticSearchTestRepository(new RepositoryClient(config["Es:Uri"], config["Es:Indices:Test"])));
             //services.AddSingleton<SqlCrudRepository<TestModel>, SqlTestRepository>(_ => new SqlTestRepository(new object()));
             

--- a/src/Enact.Api/Enact.Api.xproj
+++ b/src/Enact.Api/Enact.Api.xproj
@@ -10,7 +10,7 @@
     <RootNamespace>Enact.Api</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Enact.Api/appsettings.json
+++ b/src/Enact.Api/appsettings.json
@@ -8,13 +8,13 @@
     }
   },
   "Es": {
-    "Uri": "http://localhost:9200",
+    "Uri": "http://localhost.com:9200",
     "Indices": {
       "Test": "test"
     }
   },
   "Ef": {
-    "Server": "db1",
-    "Database":  "."
+    "Server": ".",
+    "Database":  "db1"
   } 
 }

--- a/src/Enact.Api/project.json
+++ b/src/Enact.Api/project.json
@@ -14,8 +14,8 @@
     "Microsoft.Extensions.Logging": "1.0.0",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
     "Microsoft.Extensions.Logging.Debug": "1.0.0",
-    "Swashbuckle.SwaggerGen": "6.0.0-beta901",
-    "Swashbuckle.SwaggerUi": "6.0.0-beta901",
+    "Swashbuckle.SwaggerGen": "6.0.0-beta902",
+    "Swashbuckle.SwaggerUi": "6.0.0-beta902",
     "Microsoft.Extensions.PlatformAbstractions": "1.0.0",
     "Microsoft.Extensions.DependencyInjection": "1.0.0",
     "Enact.Models": "1.0.0-*",
@@ -24,17 +24,13 @@
   },
 
   "tools": {
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    }
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
   },
 
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ]
     }
@@ -47,7 +43,7 @@
   },
 
   "runtimeOptions": {
-    "gcServer": true
+    "System.GC.Server": true
   },
 
   "publishOptions": {

--- a/src/Enact.Business/Enact.Business.xproj
+++ b/src/Enact.Business/Enact.Business.xproj
@@ -10,7 +10,7 @@
     <RootNamespace>Enact.Business</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Enact.Business/project.json
+++ b/src/Enact.Business/project.json
@@ -5,11 +5,11 @@
     "Enact.Models": "1.0.0-*",
     "Enact.Repository.Es": "1.0.0-*",
     "Enact.Repository.Sql": "1.0.0-*",
-    "NETStandard.Library": "1.5.0-rc2-24027"
+    "NETStandard.Library": "1.6.0"
   },
 
   "frameworks": {
-    "netstandard1.5": {
+    "netstandard1.6": {
       "imports": "dnxcore50"
     }
   }

--- a/src/Enact.Models/Enact.Models.xproj
+++ b/src/Enact.Models/Enact.Models.xproj
@@ -11,7 +11,7 @@
     <RootNamespace>Enact.Models</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Enact.Models/project.json
+++ b/src/Enact.Models/project.json
@@ -2,12 +2,12 @@
   "version": "1.0.0-*",
 
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2-24027",
-    "Microsoft.Extensions.DependencyInjection": "1.0.0-rc2-final"
+    "NETStandard.Library": "1.6.0",
+    "Microsoft.Extensions.DependencyInjection": "1.0.0"
   },
 
   "frameworks": {
-    "netstandard1.5": {
+    "netstandard1.6": {
       "imports": "dnxcore50"
     }
   }

--- a/src/Enact.Repository.Es/Enact.Repository.Es.xproj
+++ b/src/Enact.Repository.Es/Enact.Repository.Es.xproj
@@ -11,7 +11,7 @@
     <RootNamespace>Enact.Repository.Es</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Enact.Repository.Es/project.json
+++ b/src/Enact.Repository.Es/project.json
@@ -8,7 +8,7 @@
   },
 
   "frameworks": {
-    "netstandard1.5": {
+    "netstandard1.6": {
       "imports": "dnxcore50"
     }
   }

--- a/src/Enact.Repository.Sql/Enact.Repository.Sql.xproj
+++ b/src/Enact.Repository.Sql/Enact.Repository.Sql.xproj
@@ -11,7 +11,7 @@
     <RootNamespace>Enact.Repository.Sql</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Enact.Repository.Sql/RepositoryContext.cs
+++ b/src/Enact.Repository.Sql/RepositoryContext.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+
+namespace Enact.Repository.Sql
+{
+    public class RepositoryContext : DbContext
+    {
+        private IConfigurationRoot _config;
+
+        public RepositoryContext(IConfigurationRoot config)
+        {
+            _config = config;
+        }
+
+        public DbSet<object> MyDbSet { get; set; }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            var connection = $"Server={_config["Ef:Server"]};Database={_config["Ef:Database"]};Trusted_Connection=true;MultipleActiveResultSets=true;";
+            optionsBuilder.UseSqlServer(connection);
+            base.OnConfiguring(optionsBuilder);
+        }
+    }
+}

--- a/src/Enact.Repository.Sql/project.json
+++ b/src/Enact.Repository.Sql/project.json
@@ -3,11 +3,14 @@
 
   "dependencies": {
     "Enact.Models": "1.0.0-*",
-    "NETStandard.Library": "1.5.0-rc2-24027"
+    "NETStandard.Library": "1.6.0",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0",
+    "Microsoft.EntityFrameworkCore.SqlServer.Design": "1.0.0",
+    "Microsoft.Extensions.Configuration.Abstractions": "1.0.0"
   },
 
   "frameworks": {
-    "netstandard1.5": {
+    "netstandard1.6": {
       "imports": "dnxcore50"
     }
   }

--- a/src/Enact.Spa/Enact.Spa.xproj
+++ b/src/Enact.Spa/Enact.Spa.xproj
@@ -10,7 +10,7 @@
     <RootNamespace>Enact.Cdn</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/src/Enact.Spa/project.json
+++ b/src/Enact.Spa/project.json
@@ -11,17 +11,13 @@
   },
 
   "tools": {
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-      "version": "1.0.0-preview1-final",
-      "imports": "portable-net45+win8+dnxcore50"
-    }
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
   },
 
   "frameworks": {
     "netcoreapp1.0": {
       "imports": [
         "dotnet5.6",
-        "dnxcore50",
         "portable-net45+win8"
       ]
     }


### PR DESCRIPTION
upgraded target framework to .NET 4.6.1, and ASP.NET Core to 1.0 release
(from RC2 to netstandard1.6, Tools to 1.0.0-preview2-final), also
started SQL EF repository.
